### PR TITLE
test(lib): more sweet testing about importing local crate

### DIFF
--- a/balancing-server/src/bin/main.rs
+++ b/balancing-server/src/bin/main.rs
@@ -35,14 +35,3 @@ async fn main() -> std::io::Result<()> {
         .run()
         .await
 }
-
-#[cfg(test)]
-mod test {
-    use suteravr_lib::Foo;
-
-    /// whether balancing-server can load the local suteravr-lib crate
-    #[test]
-    fn test_loading_suteravrlib() {
-        let _foo: Foo = Foo::default();
-    }
-}

--- a/balancing-server/src/lib.rs
+++ b/balancing-server/src/lib.rs
@@ -1,4 +1,4 @@
-//! Social-server
+//! Balancing-server
 //!
 //! [`suteravr-lib`][suteravr_lib]が使用できます。
 //! ```no_run

--- a/client/rust/src/lib.rs
+++ b/client/rust/src/lib.rs
@@ -1,3 +1,11 @@
+//! Client-side Rust code
+//!
+//! [`suteravr-lib`][suteravr_lib]が使用できます。
+//! ```no_run
+//! use suteravr_lib::Foo;
+//! ```
+//!
+
 use godot::prelude::*;
 
 struct MyExtension;

--- a/client/rust/src/lib.rs
+++ b/client/rust/src/lib.rs
@@ -12,14 +12,3 @@ struct MyExtension;
 
 #[gdextension]
 unsafe impl ExtensionLibrary for MyExtension {}
-
-#[cfg(test)]
-mod test {
-    use suteravr_lib::Foo;
-
-    /// whether this rust crate can load the suteravr-lib crate or not.
-    #[test]
-    fn test_loading_suteravrlib() {
-        let _foo: Foo = Foo::default();
-    }
-}

--- a/clocking-server/src/bin/main.rs
+++ b/clocking-server/src/bin/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, World");
+}

--- a/clocking-server/src/lib.rs
+++ b/clocking-server/src/lib.rs
@@ -1,10 +1,7 @@
-#[cfg(test)]
-mod tests {
-    use suteravr_lib::Foo;
-
-    /// whether clocking-server can load the suteravr-lib crate or not
-    #[test]
-    fn test_loading_suteravrlib() {
-        let _foo: Foo = Foo::default();
-    }
-}
+//! Clocking-server
+//!
+//! [`suteravr-lib`][suteravr_lib]が使用できます。
+//! ```no_run
+//! use suteravr_lib::Foo;
+//! ```
+//!

--- a/suteravr-lib/src/lib.rs
+++ b/suteravr-lib/src/lib.rs
@@ -1,2 +1,1 @@
-#[derive(Default)]
 pub struct Foo {}


### PR DESCRIPTION
- #74 で私がレビューで指摘しつつ改善策思いつけなかったやつの改善策

ドキュメンテーションテストなら「コンパイルが通る」ってテストが書けるんだわ (`no_run`)
すっかり忘れてたぜ

- Add documentation tests
- Remove deriving Default
