### PR TITLE
chore(godot/rust,clocking): reduce log and log level

### DIFF
--- a/client/rust/src/async_driver.rs
+++ b/client/rust/src/async_driver.rs
@@ -1,6 +1,6 @@
 use futures::Future;
 use godot::{engine::Engine, prelude::*};
-use suteravr_lib::info;
+use suteravr_lib::{debug, info};
 use tokio::{
     runtime::{Builder, Runtime},
     task::JoinHandle,
@@ -42,7 +42,7 @@ impl AsyncExecutorDriver {
         name: &str,
         f: impl Future<Output = T> + Send + 'static,
     ) -> JoinHandle<T> {
-        info!(self.logger, "Spawning task: {}", name);
+        debug!(self.logger, "Spawning task: {}", name);
         self.runtime.spawn(f)
     }
 }

--- a/client/rust/src/logger.rs
+++ b/client/rust/src/logger.rs
@@ -6,8 +6,8 @@ pub struct GodotLogger {
 }
 
 impl Logger for GodotLogger {
-    fn write_debug(&self, data: String) {
-        godot_print!("[DEBUG {}] {}", self.target, data);
+    fn write_debug(&self, _data: String) {
+        // godot_print!("[DEBUG {}] {}", self.target, data);
     }
     fn write_info(&self, data: String) {
         godot_print!("[INFO  {}] {}", self.target, data);

--- a/client/rust/src/tcp/mod.rs
+++ b/client/rust/src/tcp/mod.rs
@@ -11,7 +11,7 @@ use suteravr_lib::{
         chat_entry::SendChatMessageRequest,
         login::{LoginRequest, LoginResponse},
     },
-    error,
+    debug, error,
     util::serialize_to_new_vec,
 };
 
@@ -191,7 +191,7 @@ impl ClockerConnection {
             )
             .await?;
             let result = deserialize::<LoginResponse, LoginResponse>(&login_result.payload)?;
-            info!(logger, "ChatMessage sent: {:?}", result);
+            debug!(logger, "ChatMessage sent: {:?}", result);
             Ok::<(), TcpServerError>(())
         });
     }

--- a/suteravr-lib/src/clocking/buffer.rs
+++ b/suteravr-lib/src/clocking/buffer.rs
@@ -1,6 +1,6 @@
 use crate::clocking::ClockingFrameUnit;
 use crate::util::logger::Logger;
-use crate::{debug, error, info, warn};
+use crate::{debug, error, warn};
 
 use super::event_headers::EventHeader;
 use super::oneshot_headers::OneshotHeader;
@@ -120,7 +120,7 @@ impl<T: Logger> FrameBuffer<T> {
                             content_header: ContentHeader::Oneshot(oneshot_header),
                             payload,
                         };
-                        info!(self.logger, "Receive: {:?}", &request);
+                        debug!(self.logger, "Receive: {:?}", &request);
                         self.clear();
                         return Some(request);
                     }
@@ -131,7 +131,7 @@ impl<T: Logger> FrameBuffer<T> {
                             content_header: ContentHeader::Event(event_header),
                             payload,
                         };
-                        info!(self.logger, "Receive: {:?}", &request);
+                        debug!(self.logger, "Receive: {:?}", &request);
                         self.clear();
                         return Some(request);
                     }

--- a/suteravr-lib/src/clocking/schemas/oneshot/chat_entry.rs
+++ b/suteravr-lib/src/clocking/schemas/oneshot/chat_entry.rs
@@ -1,18 +1,23 @@
 use alkahest::alkahest;
 use chrono::{DateTime, Local};
+use derivative::Derivative;
 
 use crate::messaging::id::PlayerId;
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
 pub struct ChatEntry {
+    #[derivative(Debug = "ignore")]
     pub send_at: DateTime<Local>,
     pub sender: PlayerId,
     pub message: String,
 }
 
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 #[alkahest(Formula, Serialize, Deserialize)]
 pub struct SendableChatEntry {
+    #[derivative(Debug = "ignore")]
     pub send_at: String,
     pub sender: PlayerId,
     pub message: String,


### PR DESCRIPTION
通信のログが全部出ててうざかったので

- 通信のログを[INFO]から[DEBUG]に変更しました
- Godotのコンソールに出力するのはINFO以上のログにしました